### PR TITLE
Fix typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ export default defineConfig({
 
 for hmr to work simply import "fontasticon:<font name>" somewhere in your code
 ```typescript
-import "fontasticon:icons";
+import "fantasticon:icons";
 import "fontasticon:my-other-font";
 ```
 


### PR DESCRIPTION
When using the plugin, I faced the issue that my font wasn't loading correctly. 
This is due to an typo inside the documentation.
Took some time to find the typo, since I copied it straight from the documentation.

So I figured I should create a pull request, so this issue doesn't happen to another user.