### PR TITLE
feat: handle base url

### DIFF
--- a/src/hmr-template.ts
+++ b/src/hmr-template.ts
@@ -12,13 +12,14 @@ import.${"meta"}.hot && import.${"meta"}.hot.on("${event}", () => {
 
 export const hmrLinkTag = (
   config: RunnerOptions,
+  base: string,
   id: string
 ): HtmlTagDescriptor => ({
   tag: "link",
   attrs: {
     rel: "stylesheet",
     type: "text/css",
-    href: `/${assetPath(config, "css" as any)}?${Date.now()}`,
+    href: `${base}${assetPath(config, "css" as any)}?${Date.now()}`,
     "data-id": id,
   },
   injectTo: "head",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -20,15 +20,19 @@ export function fantasticon(options?: FantasticonOptions): PluginOption {
   const name = `fantasticon:${config.name}`;
   const virtual = `\0${name}`;
   const updateEvent = `${name}:update`;
+  let base = "/";
 
   let ws: WebSocketServer | undefined = undefined;
 
   function transformIndexHtml(html: string) {
-    return { html, tags: [hmrLinkTag(config, name)] };
+    return { html, tags: [hmrLinkTag(config, base, name)] };
   }
 
   return {
     name,
+    configResolved(config) {
+      base = config.base;
+    },
     async buildStart() {
       builder.watch(() => ws, updateEvent);
       await builder.build();


### PR DESCRIPTION
Adding base URL to the generated link tag so it plays nice when not in root.

Some context:

If you use:
```
export default defineConfig({
  base: "/any/base",
  ...
});
```

That should be reflected on the imported assets.